### PR TITLE
fix(docs): remove reference to manual release process

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,3 @@ The available event models are:
 - `SubgroupEvent`
 - `TagPushEvent`
 - `WikiPageEvent`
-
-## Making a release
-
-[Manually
-trigger](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/manually-running-a-workflow)
-the release workflow.


### PR DESCRIPTION
The release process is now completely automated and so the README need not cover how to make a release.