### PR TITLE
accept more issue event types and be more liberal in `null` values within changes

### DIFF
--- a/pydantic_gitlab_webhooks/_common.py
+++ b/pydantic_gitlab_webhooks/_common.py
@@ -58,7 +58,7 @@ class Note(BaseModel, _TimestampedMixin, _IdentifiableMixin):
 
 class Label(BaseModel, _TimestampedMixin, _IdentifiableMixin):
     # See "hook_attrs" in https://gitlab.com/gitlab-org/gitlab/-/blob/master/app/models/label.rb
-    title: str
+    title: Optional[str]
     color: str
     project_id: Optional[int]
     template: bool
@@ -100,7 +100,7 @@ class Project(BaseModel, _IdentifiableMixin):
 
 class Issue(BaseModel, _TimestampedMixin, _IdentifiableMixin):
     # See: https://gitlab.com/gitlab-org/gitlab/-/blob/master/lib/gitlab/hook_data/issue_builder.rb
-    title: str
+    title: Optional[str]
     assignee_ids: list[int]
     assignee_id: Optional[int]
     author_id: int
@@ -122,7 +122,7 @@ class Commit(BaseModel):
     # See: "hook_attrs" in https://gitlab.com/gitlab-org/gitlab/-/blob/master/app/models/commit.rb
     id: str
     message: str = ""
-    title: str = ""
+    title: Optional[str] = ""
     timestamp: Datetime
     url: AnyHttpUrl
     author: CommitAuthor
@@ -135,13 +135,13 @@ class MergeRequest(BaseModel, _TimestampedMixin, _IdentifiableMixin):
     source_project_id: int
     author_id: int
     assignee_id: Optional[int]
-    title: str
+    title: Optional[str]
     milestone_id: Optional[int]
     state: str
     merge_status: str
     target_project_id: int
     iid: int
-    description: str
+    description: Optional[str]
     position: Optional[int] = None
     labels: list[Label]
     source: Optional[Project]
@@ -154,7 +154,7 @@ class MergeRequest(BaseModel, _TimestampedMixin, _IdentifiableMixin):
 
 class Snippet(BaseModel, _TimestampedMixin, _IdentifiableMixin):
     # See "hook_attrs" in https://gitlab.com/gitlab-org/gitlab/-/blob/master/app/models/snippet.rb
-    title: str
+    title: Optional[str]
     description: str
     content: str
     author_id: int
@@ -177,7 +177,7 @@ class Wiki(BaseModel):
 class WikiPage(BaseModel):
     # https://gitlab.com/gitlab-org/gitlab/-/blob/master/lib/gitlab/hook_data/wiki_page_builder.rb
     # https://gitlab.com/gitlab-org/gitlab/-/blob/master/app/models/wiki_page.rb
-    title: str
+    title: Optional[str]
     content: str
     format: str
     message: str

--- a/pydantic_gitlab_webhooks/_issue_event.py
+++ b/pydantic_gitlab_webhooks/_issue_event.py
@@ -12,10 +12,10 @@ class Issue(BaseIssue):
 
 
 class Changes(BaseModel):
-    title: Optional[Change[str]] = None
-    assignee_ids: Optional[Change[list[int]]] = None
+    title: Optional[Change[Optional[str]]] = None
+    assignee_ids: Optional[Change[Optional[list[int]]]] = None
     assignee_id: Optional[Change[Optional[int]]] = None
-    description: Optional[Change[str]] = None
+    description: Optional[Change[Optional[str]]] = None
     milestone_id: Optional[Change[Optional[int]]] = None
     state: Optional[Change[str]] = None
-    labels: Optional[Change[list[Label]]] = None
+    labels: Optional[Change[Optional[list[Label]]]] = None

--- a/pydantic_gitlab_webhooks/_merge_request_event.py
+++ b/pydantic_gitlab_webhooks/_merge_request_event.py
@@ -27,13 +27,13 @@ class Changes(BaseModel):
     target_branch: Optional[Change[str]] = None
     source_branch: Optional[Change[str]] = None
     assignee_id: Optional[Change[Optional[int]]] = None
-    title: Optional[Change[str]] = None
+    title: Optional[Change[Optional[str]]] = None
     milestone_id: Optional[Change[Optional[int]]] = None
     state: Optional[Change[str]] = None
     merge_status: Optional[Change[str]] = None
-    description: Optional[Change[str]] = None
-    labels: Optional[Change[list[Label]]] = None
-    last_commit: Optional[Change[Commit]] = None
+    description: Optional[Change[Optional[str]]] = None
+    labels: Optional[Change[Optional[list[Label]]]] = None
+    last_commit: Optional[Change[Optional[Commit]]] = None
     draft: Optional[Change[bool]] = None
     assignee: Optional[Change[Optional[User]]] = None
     detailed_merge_status: Optional[Change[str]] = None

--- a/pydantic_gitlab_webhooks/events.py
+++ b/pydantic_gitlab_webhooks/events.py
@@ -87,7 +87,8 @@ class TagPushEvent(_BasePushEvent):
 class IssueEvent(BaseModel):
     # https://gitlab.com/gitlab-org/gitlab/-/blob/master/lib/gitlab/hook_data/issue_builder.rb
     object_kind: Literal["issue"] | Literal["work_item"]
-    event_type: Literal["issue"]
+    # all the docs say is 'the object_kind field is work_item, and the type is the work item type.'
+    event_type: str
     user: User
     project: Project
     object_attributes: _issue_event.Issue


### PR DESCRIPTION
The [docs][1] are somewhat sparsely specified for what `event_type` can be for issues. In particular they don't list the literal values it can take and instead say it is the "work item type".

Additionally, in the real world we've been seeing a lot of the fields in `changes` start as `null` and so add that to the schema for issues and merge requests.

[1]: https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html#work-item-events