### PR TITLE
Actualizing optional fields in webhook payload to avoid validation failures

### DIFF
--- a/pydantic_gitlab_webhooks/_common.py
+++ b/pydantic_gitlab_webhooks/_common.py
@@ -106,7 +106,7 @@ class Issue(BaseModel, _TimestampedMixin, _IdentifiableMixin):
     assignee_ids: list[int]
     assignee_id: Optional[int]
     author_id: int
-    project_id: int
+    project_id: Optional[int] = None
     position: Optional[int] = None
     description: Optional[str] = None
     milestone_id: Optional[int]
@@ -199,7 +199,7 @@ class Pipeline(BaseModel, _IdentifiableMixin):
     # See "hook_attrs()" in
     # https://gitlab.com/gitlab-org/gitlab/-/blob/master/lib/gitlab/data_builder/pipeline.rb
     iid: int
-    name: str
+    name: Optional[str] = None
     ref: str
     tag: bool
     sha: str
@@ -208,8 +208,8 @@ class Pipeline(BaseModel, _IdentifiableMixin):
     status: str
     stages: list[str]
     created_at: Datetime
-    finished_at: Datetime
-    duration: int
+    finished_at: Optional[Datetime] = None
+    duration: Optional[int] = None
     variables: list[PipelineVariable]
     url: AnyHttpUrl
 

--- a/pydantic_gitlab_webhooks/events.py
+++ b/pydantic_gitlab_webhooks/events.py
@@ -90,7 +90,7 @@ class IssueEvent(BaseModel):
     # all the docs say is 'the object_kind field is work_item, and the type is the work item type.'
     event_type: str
     user: User
-    project: Project
+    project: Optional[Project] = None
     object_attributes: _issue_event.Issue
     assignees: Optional[list[User]] = None
     assignee: Optional[User] = None


### PR DESCRIPTION
Hey @rjw57, we validated the webhook payload from the live GitLab instance at some time and found that some fields here are optional. 

Here, issues w/o a project_id/Project are Epics. Maybe it make sense to have separate data model for them but for now I suggest to just make those fields optional. 